### PR TITLE
Dynamic PORT selection for PFC storm testing

### DIFF
--- a/tests/telemetry/events/swss_events.py
+++ b/tests/telemetry/events/swss_events.py
@@ -8,7 +8,6 @@ from run_events_test import run_test
 logger = logging.getLogger(__name__)
 tag = "sonic-events-swss"
 
-PFC_STORM_TEST_PORT = "Ethernet4"
 PFC_STORM_TEST_QUEUE = "4"
 PFC_STORM_DETECTION_TIME = 100
 PFC_STORM_RESTORATION_TIME = 100
@@ -45,6 +44,11 @@ def shutdown_interface(duthost):
 
 def generate_pfc_storm(duthost):
     logger.info("Generating pfc storm")
+    interfaces = duthost.get_interfaces_status()
+    PFC_STORM_TEST_PORT = next((interface for interface, status in interfaces.items()
+                               if status["oper"] == "up" and status["admin"] == "up"), None)
+    assert PFC_STORM_TEST_PORT is not None, "Unable to find valid interface for test"
+
     queue_oid = duthost.get_queue_oid(PFC_STORM_TEST_PORT, PFC_STORM_TEST_QUEUE)
     duthost.shell("sonic-db-cli COUNTERS_DB HSET \"COUNTERS:{}\" \"DEBUG_STORM\" \"enabled\"".
                   format(queue_oid))


### PR DESCRIPTION
In the test file : telemetry/events/swss_events.py in the function generate_pfc_storm, in the line
queue_oid = duthost.get_queue_oid(PFC_STORM_TEST_PORT, PFC_STORM_TEST_QUEUE) The PFC_STORM_TEST_PORT - the port chosen to test the PFC storm on - is assigned a fixed value of “Ethernet4”, whereas, the T0-crocodile DUT does not have a port Ethernet4 associated with it’s ASIC instance. Therefore this test is passing when assigning a value of Ethernet8 or Ethernet16 which are valid ports.

Changing fixed assigned value, replacing it with a dynamically selected port from the list of ports that have both open and admin status as "UP"

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [ ] 202205
- [x] 202305

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
